### PR TITLE
fix: 🐛 template renderer will stop using old links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ All notable changes the Codefair App will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v3.1.1 - 11-12-2024
 
-## v.3.1.0 - 11-05-2024
+### Fixed
+
+- Remove outdated URL links in the template renderer to ensure the correct and current links are used for metadata, CWL, and license templates.
+
+## v3.1.0 - 11-05-2024
 
 ### Added
 
@@ -22,13 +27,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Stop updating the date for "first released date" in the existing codemeta.json file
 - Fixed spacing between the "Open a GitHub issue" and icon in the home page.
 
-## v.3.0.0 - 2024-10-17
+## v3.0.0 - 2024-10-17
 
 ### Added
 
 - A new workflow has been implemented to streamline the integration of the GitHub release process with Zenodo archiving. This enhancement ensures that metadata is updated prior to each GitHub release, allowing for a more accurate and up-to-date archived version of the repository on Zenodo. This change simplifies the release process and enhances the accessibility of our project's data.
 
-## v.2.0.1 - 2024-09-03
+## v2.0.1 - 2024-09-03
 
 ### Identifier
 
@@ -48,8 +53,7 @@ https://doi.org/10.5281/zenodo.13651177
 
 - Removed references to the action key in the database as it was not being used.
 
-
-## v.2.0.0 - 2024-08-29
+## v2.0.0 - 2024-08-29
 
 ### Identifier
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,4 +33,4 @@ keywords:
 license: MIT
 repository-code: https://github.com/fairdataihub/codefair-app
 date-released: '2024-11-11'
-version: 3.1.0
+version: 3.1.1

--- a/bot/cwl/index.js
+++ b/bot/cwl/index.js
@@ -258,9 +258,6 @@ export async function applyCWLTemplate(
     }
   } else {
     // An entry exists in the db, thus possible old files exist (merge both lists)
-    if (existingCWL?.identifier) {
-      url = `${CODEFAIR_DOMAIN}/view/cwl-validation/${existingCWL.identifier}`;
-    }
     validOverall = true;
     const fileMap = new Map();
 

--- a/bot/license/index.js
+++ b/bot/license/index.js
@@ -247,9 +247,6 @@ export async function applyLicenseTemplate(
 
   if (existingLicense) {
     consola.info("Updating existing license request...");
-    if (existingLicense?.identifier) {
-      badgeURL = `${CODEFAIR_DOMAIN}/add/license/${existingLicense.identifier}`;
-    }
     await dbInstance.licenseRequest.update({
       data: {
         contains_license: subjects.license,

--- a/bot/metadata/index.js
+++ b/bot/metadata/index.js
@@ -454,13 +454,12 @@ export async function applyMetadataTemplate(
   owner,
   context,
 ) {
+  let url = `${CODEFAIR_DOMAIN}/dashboard/${owner}/${repository.name}/edit/code-metadata`;
   if ((!subjects.codemeta || !subjects.citation) && subjects.license) {
     // License was found but no codemeta.json or CITATION.cff exists
     const identifier = createId();
     let validCitation = false;
     let validCodemeta = false;
-
-    let url = `${CODEFAIR_DOMAIN}/dashboard/${owner}/${repository.name}/edit/code-metadata`;
 
     const existingMetadata = await dbInstance.codeMetadata.findUnique({
       where: {
@@ -530,10 +529,6 @@ export async function applyMetadataTemplate(
         },
         where: { repository_id: repository.id },
       });
-
-      if (existingMetadata?.identifier) {
-        url = `${CODEFAIR_DOMAIN}/add/code-metadata/${existingMetadata.identifier}`;
-      }
     }
     const metadataBadge = `[![Metadata](https://img.shields.io/badge/Add_Metadata-dc2626.svg)](${url})`;
     baseTemplate += `\n\n## Metadata ❌\n\nTo make your software FAIR, a CITATION.cff and codemeta.json are expected at the root level of your repository. These files are not found in the repository. If you would like Codefair to add these files, click the "Add metadata" button below to go to our interface for providing metadata and generating these files.\n\n${metadataBadge}`;
@@ -562,8 +557,6 @@ export async function applyMetadataTemplate(
 
     // License, codemeta.json and CITATION.cff files were found
     const identifier = createId();
-
-    let url = `${CODEFAIR_DOMAIN}/add/code-metadata/${identifier}`;
 
     const existingMetadata = await dbInstance.codeMetadata.findUnique({
       where: {
@@ -607,8 +600,6 @@ export async function applyMetadataTemplate(
         },
         where: { repository_id: repository.id },
       });
-
-      url = `${CODEFAIR_DOMAIN}/add/code-metadata/${existingMetadata.identifier}`;
     }
     const metadataBadge = `[![Metadata](https://img.shields.io/badge/Edit_Metadata-0ea5e9.svg)](${url}?)`;
     baseTemplate += `\n\n## Metadata ✔️\n\nA CITATION.cff and a codemeta.json file are found in the repository. They may need to be updated over time as new people are contributing to the software, etc.\n\n${metadataBadge}`;

--- a/codemeta.json
+++ b/codemeta.json
@@ -65,7 +65,7 @@
   "relatedLink": [
     "https://docs.codefair.io/"
   ],
-  "schema:releaseNotes": "## v.3.1.0 - 11-05-2024\n\n### Added\n\n- Enhance logging by adding more informative messages and removing redundant logs.\n- Added NuxtLinks to external resources in the Codefair description\n- Modified the GitHub issue button layout\n- Improved error handling when publishing to Zenodo\n- Improved handling of 'no-license' and 'NOASSERTION' cases in the SPDX license detection\n\n### Fixed\n\n- Patched issue with PR link not being replaced correctly in the Metadata section of the FAIR Compliance Dashboard Issue\n- Stop updating the date for \"first released date\" in the existing codemeta.json file\n- Fixed spacing between the \"Open a GitHub issue\" and icon in the home page.",
-  "version": "3.1.0",
+  "schema:releaseNotes": "## v3.1.1 - 11-12-2024\n\n### Fixed\n\n- Remove outdated URL links in the template renderer to ensure the correct and current links are used for metadata, CWL, and license templates.",
+  "version": "3.1.1",
   "type": "SoftwareSourceCode"
 }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove outdated URL links in the template renderer to ensure the correct and current links are used for metadata, CWL, and license templates.