### PR TITLE
fix: 🐛 Update Validator's Dockerfile

### DIFF
--- a/bot/compliance-checks/license/index.js
+++ b/bot/compliance-checks/license/index.js
@@ -207,6 +207,13 @@ export async function updateLicenseDatabase(repository, license) {
     logwatch.info(
       `Creating new license entry for repo: ${repository.name} (ID: ${repository.id})`
     );
+    // If license exists in repo, validate it (handles NOASSERTION/custom cases)
+    if (license.status) {
+      ({ licenseId, licenseContent, licenseContentEmpty } = validateLicense(
+        license,
+        null
+      ));
+    }
     existingLicense = await dbInstance.licenseRequest.create({
       data: {
         identifier: createId(),

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application files
 COPY apis ./apis
-COPY config.py app.py entrypoint.sh codemeta-schema.json ./ 
+COPY config.py app.py entrypoint.sh codemeta-schema.json codemeta-schema2.0.json ./
 
 # Optional: Ensure the entrypoint script is executable
 RUN chmod +x entrypoint.sh


### PR DESCRIPTION
…se entries

## Summary by Sourcery

Validate and persist license information when creating new license entries and ensure the validator Docker image includes all required codemeta schema files.

Bug Fixes:
- Validate license data during new license entry creation to correctly handle existing, NOASSERTION, and custom license cases.
- Include the additional codemeta schema JSON file in the validator Docker image build context so validation can use it.