### PR TITLE
refactor: ♻️ Use GitHub's licensee engine for license detection

### DIFF
--- a/ui/prisma/migrations/20260701183609_add_license_path_to_license_request/migration.sql
+++ b/ui/prisma/migrations/20260701183609_add_license_path_to_license_request/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "LicenseRequest" ADD COLUMN     "license_path" TEXT NOT NULL DEFAULT '';

--- a/ui/prisma/schema.prisma
+++ b/ui/prisma/schema.prisma
@@ -59,6 +59,7 @@ model LicenseRequest {
   contains_license     Boolean      @default(false)
   license_status       String       @default("")
   license_id           String?
+  license_path         String       @default("")
   license_content      String       @default("")
   pull_request_url     String       @default("")
   created_at           DateTime     @default(now())

--- a/ui/server/services/compliance/license.ts
+++ b/ui/server/services/compliance/license.ts
@@ -89,12 +89,7 @@ export async function checkForLicense(
   repo: string,
 ): Promise<LicenseResult> {
   // Primary path: let the provider detect the license file automatically.
-  const detected = await provider.detectLicense(owner, repo).catch(() => ({
-    name: null,
-    content: null,
-    path: null,
-    spdxId: null,
-  }));
+  const detected = await provider.detectLicense(owner, repo);
 
   if (detected.path) {
     return {

--- a/ui/server/services/compliance/license.ts
+++ b/ui/server/services/compliance/license.ts
@@ -17,6 +17,7 @@ export interface LicenseResult {
 interface ExistingLicense {
   id: string;
   license_id: string | null;
+  license_path: string;
   license_content: string;
   license_status: string;
   contains_license: boolean;
@@ -59,7 +60,13 @@ function normalizeContent(content: string | null | undefined): string {
 
 // == Public API ===============================================================
 
-const LICENSE_PATHS = ["LICENSE", "LICENSE.md", "LICENSE.txt"];
+const LICENSE_PATHS = [
+  "LICENSE",
+  "LICENSE.md",
+  "LICENSE.txt",
+  "COPYING",
+  "COPYING.LESSER",
+];
 
 /**
  * Checks whether a LICENSE file exists in the repository and detects its SPDX ID.
@@ -205,6 +212,7 @@ export async function updateLicenseDatabase(
   let licenseId: string | null = license.spdx_id;
   let licenseContent = license.content;
   let licenseContentEmpty = license.content === "";
+  let licensePath = license.status ? license.path : "";
 
   const existingLicense = await prisma.licenseRequest.findUnique({
     where: { repository_id: repositoryId },
@@ -222,6 +230,7 @@ export async function updateLicenseDatabase(
       licenseId = existingLicense.license_id;
       licenseContent = existingLicense.license_content;
       licenseContentEmpty = !licenseContent;
+      licensePath = existingLicense.license_path;
     }
 
     return prisma.licenseRequest.update({
@@ -229,6 +238,7 @@ export async function updateLicenseDatabase(
         contains_license: license.status,
         license_status: licenseContentEmpty ? "invalid" : "valid",
         license_id: licenseId,
+        license_path: licensePath,
         license_content: licenseContent,
         custom_license_title:
           licenseId === "Custom" ? existingLicense.custom_license_title : "",
@@ -252,6 +262,7 @@ export async function updateLicenseDatabase(
       contains_license: license.status,
       license_status: licenseContentEmpty ? "invalid" : "valid",
       license_id: licenseId,
+      license_path: licensePath,
       license_content: licenseContent,
       custom_license_title: "",
       repository: { connect: { id: repositoryId } },

--- a/ui/server/services/compliance/license.ts
+++ b/ui/server/services/compliance/license.ts
@@ -60,6 +60,8 @@ function normalizeContent(content: string | null | undefined): string {
 
 // == Public API ===============================================================
 
+// Fallback file names, only scanned when the provider's own license
+// detection (GitHub's licensee engine) can't classify a file.
 const LICENSE_PATHS = [
   "LICENSE",
   "LICENSE.md",
@@ -71,6 +73,11 @@ const LICENSE_PATHS = [
 /**
  * Checks whether a LICENSE file exists in the repository and detects its SPDX ID.
  *
+ * Delegated to GitHub's `licensee` engine, which
+ * locates the license file by name regardless of convention and returns its
+ * path, content, and SPDX id in one call. The hardcoded {@link LICENSE_PATHS}
+ * list is only consulted as a fallback when the provider finds nothing.
+ *
  * @param provider - The repository provider used to fetch file contents and detect licenses.
  * @param owner - The repository owner (user or organization name).
  * @param repo - The repository name.
@@ -81,23 +88,38 @@ export async function checkForLicense(
   owner: string,
   repo: string,
 ): Promise<LicenseResult> {
+  // Primary path: let the provider detect the license file automatically.
+  const detected = await provider.detectLicense(owner, repo).catch(() => ({
+    name: null,
+    content: null,
+    path: null,
+    spdxId: null,
+  }));
+
+  if (detected.path) {
+    return {
+      status: true,
+      path: detected.path,
+      content: detected.content ?? "",
+      spdx_id: detected.spdxId,
+    };
+  }
+
+  // Fallback: the provider didn't classify a license, but a license-shaped
+  // file may still exist under a conventional name. Flag it so it can be
+  // resolved as a custom license downstream.
   for (const filePath of LICENSE_PATHS) {
     const file = await provider.getFileContent(owner, repo, filePath);
     if (file) {
-      // Try to get SPDX ID from GitHub's license detection
-      const detected = await provider.detectLicense(owner, repo).catch(() => ({
-        spdxId: null,
-        name: null,
-      }));
-
       return {
         status: true,
         path: filePath,
         content: file.content,
-        spdx_id: detected.spdxId,
+        spdx_id: null,
       };
     }
   }
+
   return {
     status: false,
     path: "No LICENSE file found",
@@ -132,7 +154,8 @@ export function validateLicense(
     if (licenseId === "no-license" || !licenseId) {
       logwatch.warn({
         ...logCtx,
-        message: "License ID is missing or unrecognized — treating as no license",
+        message:
+          "License ID is missing or unrecognized — treating as no license",
         spdxId: license.spdx_id,
       });
       licenseId = null;
@@ -144,7 +167,8 @@ export function validateLicense(
       if (licenseContentEmpty) {
         logwatch.warn({
           ...logCtx,
-          message: "NOASSERTION license with empty content — treating as no license",
+          message:
+            "NOASSERTION license with empty content. Treating as no license",
         });
         licenseId = null;
       } else {
@@ -163,7 +187,7 @@ export function validateLicense(
           logwatch.warn({
             ...logCtx,
             existingLicenseId: existingLicense?.license_id ?? null,
-            message: "NOASSERTION license content changed — resolving as Custom",
+            message: "NOASSERTION license content changed. Resolving as Custom",
           });
           licenseId = "Custom";
         } else if (existingIsValidSpdx) {
@@ -172,13 +196,15 @@ export function validateLicense(
           logwatch.warn({
             ...logCtx,
             existingLicenseId: existingLicense.license_id,
-            message: "NOASSERTION license with non-SPDX existing ID — reusing existing",
+            message:
+              "NOASSERTION license with non-SPDX existing ID. Reusing existing",
           });
           licenseId = existingLicense.license_id;
         } else {
           logwatch.warn({
             ...logCtx,
-            message: "NOASSERTION license with no existing record — resolving as Custom",
+            message:
+              "NOASSERTION license with no existing record. Resolving as Custom",
           });
           licenseId = "Custom";
         }

--- a/ui/server/services/dashboard/manager.ts
+++ b/ui/server/services/dashboard/manager.ts
@@ -498,7 +498,7 @@ async function _subjectsFromDb(repositoryId: number): Promise<{
     cwl: null,
     license: {
       content: licenseDb?.license_content ?? "",
-      path: "",
+      path: licenseDb?.license_path ?? "",
       spdx_id: licenseDb?.license_id ?? null,
       status: licenseDb?.contains_license ?? false,
     },

--- a/ui/server/services/dashboard/renderer.ts
+++ b/ui/server/services/dashboard/renderer.ts
@@ -541,19 +541,23 @@ function renderLicense(
   const badgeURL = `${DOMAIN}/dashboard/${owner}/${repo}/edit/license`;
   const badge = `[![License](https://img.shields.io/badge/${license.status ? "Edit_License-0ea5e9" : "Add_License-dc2626"}.svg)](${badgeURL})`;
 
+  // Fall back to a generic filename when the stored path is empty (e.g. an
+  // existing LicenseRequest row that predates path tracking / backfill).
+  const licenseFile = license.path.trim() || "LICENSE";
+
   let section = "";
   if (license.status && licenseId && licenseId !== "Custom") {
-    section = `## LICENSE ✔️\n\nA \`${license.path}\` file is found at the root level of the repository.\n\n**Detected license:** \`${licenseId}\`\n\n${badge}\n\n`;
+    section = `## LICENSE ✔️\n\nA \`${licenseFile}\` file is found in the repository.\n\n**Detected license:** \`${licenseId}\`\n\n${badge}\n\n`;
   } else if (license.status && licenseId === "Custom" && !customLicenseTitle) {
     section =
-      `## LICENSE ❗\n\nYour \`${license.path}\` file needs verification. This can happen when:\n` +
+      `## LICENSE ❗\n\nYour \`${licenseFile}\` file needs verification. This can happen when:\n` +
       `- Your license content was modified and we need you to confirm the license type\n` +
       `- You're using a license that GitHub doesn't recognize but may still be a valid SPDX license\n` +
       `- You're using a truly custom license\n\n` +
       `> [!NOTE]\n> If you plan to archive on Zenodo, you'll need to select a license from the SPDX license list. Custom licenses are not currently supported by Zenodo's API.\n\n` +
       `Click the "Edit license" button below to **confirm your license type** (select from the dropdown and choose "Keep existing content") or provide a custom license title.\n\n${badge}\n\n`;
   } else if (license.status && licenseId === "Custom" && customLicenseTitle) {
-    section = `## LICENSE ✔️\n\nA custom \`${license.path}\` file titled as **${customLicenseTitle}**, has been found at the root level of this repository. If you would like to update the title or change license, click the "Edit license" button below.\n\n${badge}\n\n`;
+    section = `## LICENSE ✔️\n\nA custom \`${licenseFile}\` file titled as **${customLicenseTitle}**, has been found in this repository. If you would like to update the title or change license, click the "Edit license" button below.\n\n${badge}\n\n`;
   } else {
     section =
       `## LICENSE ❌\n\nTo make your software reusable, a \`LICENSE\` file is expected at the root level of your repository.\n` +

--- a/ui/server/services/dashboard/renderer.ts
+++ b/ui/server/services/dashboard/renderer.ts
@@ -543,7 +543,7 @@ function renderLicense(
 
   let section = "";
   if (license.status && licenseId && licenseId !== "Custom") {
-    section = `## LICENSE ✔️\n\nA \`${license.path}\` file is found at the root level of the repository.\n\n**Detected license:** \`${licenseId}\` (SPDX identifier)\n\n${badge}\n\n`;
+    section = `## LICENSE ✔️\n\nA \`${license.path}\` file is found at the root level of the repository.\n\n**Detected license:** \`${licenseId}\`\n\n${badge}\n\n`;
   } else if (license.status && licenseId === "Custom" && !customLicenseTitle) {
     section =
       `## LICENSE ❗\n\nYour \`${license.path}\` file needs verification. This can happen when:\n` +

--- a/ui/server/services/dashboard/renderer.ts
+++ b/ui/server/services/dashboard/renderer.ts
@@ -543,17 +543,17 @@ function renderLicense(
 
   let section = "";
   if (license.status && licenseId && licenseId !== "Custom") {
-    section = `## LICENSE ✔️\n\nA \`LICENSE\` file is found at the root level of the repository.\n\n${badge}\n\n`;
+    section = `## LICENSE ✔️\n\nA \`${license.path}\` file is found at the root level of the repository.\n\n**Detected license:** \`${licenseId}\` (SPDX identifier)\n\n${badge}\n\n`;
   } else if (license.status && licenseId === "Custom" && !customLicenseTitle) {
     section =
-      `## LICENSE ❗\n\nYour \`LICENSE\` file needs verification. This can happen when:\n` +
+      `## LICENSE ❗\n\nYour \`${license.path}\` file needs verification. This can happen when:\n` +
       `- Your license content was modified and we need you to confirm the license type\n` +
       `- You're using a license that GitHub doesn't recognize but may still be a valid SPDX license\n` +
       `- You're using a truly custom license\n\n` +
       `> [!NOTE]\n> If you plan to archive on Zenodo, you'll need to select a license from the SPDX license list. Custom licenses are not currently supported by Zenodo's API.\n\n` +
       `Click the "Edit license" button below to **confirm your license type** (select from the dropdown and choose "Keep existing content") or provide a custom license title.\n\n${badge}\n\n`;
   } else if (license.status && licenseId === "Custom" && customLicenseTitle) {
-    section = `## LICENSE ✔️\n\nA custom \`LICENSE\` file titled as **${customLicenseTitle}**, has been found at the root level of this repository. If you would like to update the title or change license, click the "Edit license" button below.\n\n${badge}\n\n`;
+    section = `## LICENSE ✔️\n\nA custom \`${license.path}\` file titled as **${customLicenseTitle}**, has been found at the root level of this repository. If you would like to update the title or change license, click the "Edit license" button below.\n\n${badge}\n\n`;
   } else {
     section =
       `## LICENSE ❌\n\nTo make your software reusable, a \`LICENSE\` file is expected at the root level of your repository.\n` +

--- a/ui/server/services/providers/github.ts
+++ b/ui/server/services/providers/github.ts
@@ -205,7 +205,8 @@ export class GitHubRepositoryProvider implements RepositoryProvider {
    * Detects the license of a repository using the GitHub license API.
    * @param owner - The repository owner.
    * @param repo - The repository name.
-   * @returns The detected license name and SPDX identifier, with `null` fields if none is found.
+   * @returns The detected license name, SPDX identifier, and the matched license
+   *   file's path and decoded content, with `null` fields if none is found.
    */
   async detectLicense(owner: string, repo: string): Promise<DetectedLicense> {
     try {
@@ -215,10 +216,16 @@ export class GitHubRepositoryProvider implements RepositoryProvider {
       );
       return {
         name: data.license?.name ?? null,
+        content: data.content
+          ? Buffer.from(data.content, "base64").toString("utf-8")
+          : null,
+        path: data.path ?? null,
         spdxId: data.license?.spdx_id ?? null,
       };
     } catch (err: any) {
-      if (err.status === 404) return { name: null, spdxId: null };
+      if (err.status === 404) {
+        return { name: null, content: null, path: null, spdxId: null };
+      }
       throw err;
     }
   }

--- a/ui/server/services/providers/interface.ts
+++ b/ui/server/services/providers/interface.ts
@@ -56,6 +56,10 @@ export interface ContributorInfo {
 export interface DetectedLicense {
   /** SPDX identifier but null when GitHub cannot detect a common one. */
   name: string | null;
+  /** Decoded UTF-8 content of the detected license file, or null when none found. */
+  content: string | null;
+  /** Path of the detected license file (e.g. "COPYING.LESSER"), or null when none found. */
+  path: string | null;
   spdxId: string | null;
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Delegate license detection to GitHub’s licensee engine while persisting and surfacing the detected license file path across backend, storage, and dashboard rendering.

New Features:
- Store and expose the repository license file path alongside detected SPDX ID and content.
- Display the actual detected license file path in the dashboard license section instead of a hardcoded name.

Enhancements:
- Use GitHub’s license API as the primary source of license path, content, and SPDX ID, falling back to conventional license-like filenames only when detection fails.
- Expand fallback license filename patterns to include common COPYING variants.
- Refine NOASSERTION license handling and logging messages for clearer diagnostics.

Chores:
- Add a Prisma migration to persist license file paths in the LicenseRequest table.